### PR TITLE
Allows migration of subvolumes which are directories instead image files

### DIFF
--- a/PVE/Storage.pm
+++ b/PVE/Storage.pm
@@ -475,7 +475,8 @@ sub storage_migrate {
 				outfunc => sub {});
 		}
 
-		my $cmd = ['/usr/bin/rsync', '--progress', '--sparse', '--whole-file',
+        $src .= "/" if(-d $src);
+        my $cmd = ['/usr/bin/rsync', '-a','--numeric-ids','--info=progress2', '--sparse', '--whole-file',        
 			   $src, "root\@${target_host}:$dst"];
 
 		my $percent = -1;
@@ -483,7 +484,7 @@ sub storage_migrate {
 		run_command($cmd, outfunc => sub {
 		    my $line = shift;
 
-		    if ($line =~ m/^\s*(\d+\s+(\d+)%\s.*)$/) {
+            if ($line =~ m/^\s*([0-9,]+\s+(\d+)%\s.*)$/) {                
 			if ($2 > $percent) {
 			    $percent = $2;
 			    print "rsync status: $1\n";


### PR DESCRIPTION
pve allows the storage type sub volume and directories instead of image files like pve with openvz. But pve-storage prevent the migration of directories. Migration copies the meta data but rsync failed and the directory is erased on the source machine. With this small change the migration of directories works.  
