### PR TITLE
Enable compression option -c during ZFS Send

### DIFF
--- a/src/PVE/Storage/ZFSPoolPlugin.pm
+++ b/src/PVE/Storage/ZFSPoolPlugin.pm
@@ -752,7 +752,7 @@ sub volume_export {
     # For zfs we always create a replication stream (-R) which means the remote
     # side will always delete non-existing source snapshots. This should work
     # for all our use cases.
-    my $cmd = ['zfs', 'send', '-Rpv'];
+    my $cmd = ['zfs', 'send', '-Rpvc'];
     if (defined($base_snapshot)) {
 	my $arg = $with_snapshots ? '-I' : '-i';
 	push @$cmd, $arg, $base_snapshot;


### PR DESCRIPTION
This change will allow PVE to utilize `ZFS Send -c` compression option to speed up intra-cluster migration and replication.

The current implementation does not compress streams which significantly slows down migration on VMs/CTs with large data sets (ie, databases, filestorage ...). For example, if a VM is assigned a 512GB ZFS dataset and is migrated into another host, the `ZFS Send` will transmit 512GB of data regardless if the VM internally used 1GB of disk space or +500GB of space. Using the `-c` option, upon migrating the VM, due to compression only used datablocks are sent significantly increasing speed.

Note that even if the underlying ZFS source and destination datasets have the setting `compression=on` (the default setting in PVE), `ZFS Send` without the `-c` option will "unpack" the blocks and send the blocks uncompressed to the receiver.

I've tested this on a production cluster on PVE 8.3.3 with many instances of VMs and CTs with ZFS datasets ranging from 16GB all the way up to 1TB+. Migration and replication works as they did before without any issues.